### PR TITLE
5 get one vendor

### DIFF
--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -6,7 +6,7 @@ class Api::V0::MarketsController < ApplicationController
   def show
     begin
       render json: MarketSerializer.new(Market.find(params[:id]))
-    rescue StandardError => e
+    rescue ActiveRecord::RecordNotFound => e
       render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
     end
   end

--- a/app/controllers/api/v0/markets_controller.rb
+++ b/app/controllers/api/v0/markets_controller.rb
@@ -7,7 +7,7 @@ class Api::V0::MarketsController < ApplicationController
     begin
       render json: MarketSerializer.new(Market.find(params[:id]))
     rescue ActiveRecord::RecordNotFound => e
-      render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
+      render json: ErrorSerializer.new(e).serialized_json, status: :not_found
     end
   end
 end 

--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -3,7 +3,7 @@ class Api::V0::VendorsController < ApplicationController
     begin
       render json: VendorSerializer.new(Market.find(params[:market_id]).vendors)
     rescue ActiveRecord::RecordNotFound => e
-      render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
+      render json: ErrorSerializer.new(e).serialized_json, status: :not_found
     end
   end
 
@@ -11,7 +11,7 @@ class Api::V0::VendorsController < ApplicationController
     begin
       render json: VendorSerializer.new(Vendor.find(params[:id]))
     rescue ActiveRecord::RecordNotFound => e
-      render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
+      render json: ErrorSerializer.new(e).serialized_json, status: :not_found
     end
   end
 end

--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -2,7 +2,15 @@ class Api::V0::VendorsController < ApplicationController
   def index
     begin
       render json: VendorSerializer.new(Market.find(params[:market_id]).vendors)
-    rescue StandardError => e
+    rescue ActiveRecord::RecordNotFound => e
+      render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
+    end
+  end
+
+  def show
+    begin
+      render json: VendorSerializer.new(Vendor.find(params[:id]))
+    rescue ActiveRecord::RecordNotFound => e
       render json: ErrorMarketSerializer.new(e).serialized_json, status: :not_found
     end
   end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,4 +1,4 @@
-class ErrorMarketSerializer
+class ErrorSerializer
   def initialize(error_object)
     @error_object = error_object
   end

--- a/app/serializers/market_serializer.rb
+++ b/app/serializers/market_serializer.rb
@@ -2,9 +2,6 @@ class MarketSerializer
   include JSONAPI::Serializer
   attributes :name, :street, :city, :county, :state, :zip, :lat, :lon
 
-  has_many :market_vendors
-  has_many :vendors, through: :market_vendors
-
   attribute :vendor_count do |object|
     object.vendors.count
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :markets, only: [:index, :show] do
-        resources :vendors, only: [:index]
+        resources :vendors, only: [:index, :show]
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v0 do
       resources :markets, only: [:index, :show] do
-        resources :vendors, only: [:index, :show]
+        resources :vendors, only: [:index]
       end
+      resources :vendors, only: [:show]
     end
   end
 end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -5,14 +5,15 @@ RSpec.describe 'Market Vendors API' do
     @market1 = create(:market)
     @market2 = create(:market)
     
-    vendor_ids = create_list(:vendor, 5).pluck(:id)
+    vendor_ids = create_list(:vendor, 6).pluck(:id)
 
-    @market_vendor1 = @market1.market_vendors.create!(vendor_id: vendor_ids[0])
-    
+    @market1.market_vendors.create!(vendor_id: vendor_ids[0])
     @market1.market_vendors.create!(vendor_id: vendor_ids[1])
     @market1.market_vendors.create!(vendor_id: vendor_ids[2])
     @market1.market_vendors.create!(vendor_id: vendor_ids[3])
     @market1.market_vendors.create!(vendor_id: vendor_ids[4])
+
+    @market2.market_vendors.create!(vendor_id: vendor_ids[5]) 
   end
   
   describe 'GET /markets/:id/vendors' do
@@ -65,59 +66,6 @@ RSpec.describe 'Market Vendors API' do
         expect(not_found[:errors].first).to have_key(:details)
         expect(not_found[:errors].first[:details]).to be_a(String)
         expect(not_found[:errors].first[:details]).to eq("Couldn't find Market with 'id'=123123123123123")
-      end
-    end
-  end
-
-  describe 'GET /markets/:id/vendors/:id' do
-    context 'using a valid vendor ID (happy path)' do
-      it 'returns the vendors details' do
-        vendor_id = @market_vendor1.vendor_id
-
-        get "/api/v0/markets/#{@market1.id}/vendors/#{vendor_id}"
-        
-        expect(response).to be_successful
-
-        vendor = JSON.parse(response.body, symbolize_names: true)[:data]
-
-        expect(vendor).to have_key(:id)
-        expect(vendor[:id]).to be_an(String)
-        expect(vendor[:type]).to eq('vendor')
-
-        expect(vendor[:attributes]).to have_key(:name)
-        expect(vendor[:attributes][:name]).to be_a(String)
-
-        expect(vendor[:attributes]).to have_key(:description)
-        expect(vendor[:attributes][:description]).to be_a(String)
-
-        expect(vendor[:attributes]).to have_key(:contact_name)
-        expect(vendor[:attributes][:contact_name]).to be_a(String)
-
-        expect(vendor[:attributes]).to have_key(:contact_phone)
-        expect(vendor[:attributes][:contact_phone]).to be_a(String)
-
-        expect(vendor[:attributes]).to have_key(:credit_accepted)
-        expect(vendor[:attributes][:credit_accepted]).to eq(true).or eq(false)
-      end
-    end
-
-    context 'using a invalid vendor ID (sad path)' do
-      it 'returns a 404 error' do
-        vendor_id = 123123123123123
-
-        get "/api/v0/markets/#{@market1.id}/vendors/#{vendor_id}"
-        
-        expect(response).to_not be_successful
-        expect(response.status).to eq(404)
-
-        not_found = JSON.parse(response.body, symbolize_names: true)
-
-        expect(not_found).to have_key(:errors)
-        expect(not_found[:errors]).to be_an(Array)
-
-        expect(not_found[:errors].first).to have_key(:details)
-        expect(not_found[:errors].first[:details]).to be_a(String)
-        expect(not_found[:errors].first[:details]).to eq("Couldn't find Vendor with 'id'=123123123123123")
       end
     end
   end

--- a/spec/requests/api/v0/market_vendors_request_spec.rb
+++ b/spec/requests/api/v0/market_vendors_request_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe 'Market Vendors API' do
     
     vendor_ids = create_list(:vendor, 5).pluck(:id)
 
-    @market1.market_vendors.create!(vendor_id: vendor_ids[0])
+    @market_vendor1 = @market1.market_vendors.create!(vendor_id: vendor_ids[0])
+    
     @market1.market_vendors.create!(vendor_id: vendor_ids[1])
     @market1.market_vendors.create!(vendor_id: vendor_ids[2])
     @market1.market_vendors.create!(vendor_id: vendor_ids[3])
@@ -24,7 +25,6 @@ RSpec.describe 'Market Vendors API' do
         vendors = JSON.parse(response.body, symbolize_names: true)[:data]
 
         expect(vendors.count).to eq(5)
-
         
         vendors.each do |vendor|
           expect(vendor).to have_key(:id)
@@ -65,6 +65,59 @@ RSpec.describe 'Market Vendors API' do
         expect(not_found[:errors].first).to have_key(:details)
         expect(not_found[:errors].first[:details]).to be_a(String)
         expect(not_found[:errors].first[:details]).to eq("Couldn't find Market with 'id'=123123123123123")
+      end
+    end
+  end
+
+  describe 'GET /markets/:id/vendors/:id' do
+    context 'using a valid vendor ID (happy path)' do
+      it 'returns the vendors details' do
+        vendor_id = @market_vendor1.vendor_id
+
+        get "/api/v0/markets/#{@market1.id}/vendors/#{vendor_id}"
+        
+        expect(response).to be_successful
+
+        vendor = JSON.parse(response.body, symbolize_names: true)[:data]
+
+        expect(vendor).to have_key(:id)
+        expect(vendor[:id]).to be_an(String)
+        expect(vendor[:type]).to eq('vendor')
+
+        expect(vendor[:attributes]).to have_key(:name)
+        expect(vendor[:attributes][:name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:description)
+        expect(vendor[:attributes][:description]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_name)
+        expect(vendor[:attributes][:contact_name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_phone)
+        expect(vendor[:attributes][:contact_phone]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:credit_accepted)
+        expect(vendor[:attributes][:credit_accepted]).to eq(true).or eq(false)
+      end
+    end
+
+    context 'using a invalid vendor ID (sad path)' do
+      it 'returns a 404 error' do
+        vendor_id = 123123123123123
+
+        get "/api/v0/markets/#{@market1.id}/vendors/#{vendor_id}"
+        
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+
+        not_found = JSON.parse(response.body, symbolize_names: true)
+
+        expect(not_found).to have_key(:errors)
+        expect(not_found[:errors]).to be_an(Array)
+
+        expect(not_found[:errors].first).to have_key(:details)
+        expect(not_found[:errors].first[:details]).to be_a(String)
+        expect(not_found[:errors].first[:details]).to eq("Couldn't find Vendor with 'id'=123123123123123")
       end
     end
   end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe 'Vendors API' do
+  before(:each) do
+    @market1 = create(:market)
+    @market2 = create(:market)
+    
+    vendor_ids = create_list(:vendor, 5).pluck(:id)
+
+    @market_vendor1 = @market1.market_vendors.create!(vendor_id: vendor_ids[0])
+    
+    @market1.market_vendors.create!(vendor_id: vendor_ids[1])
+    @market1.market_vendors.create!(vendor_id: vendor_ids[2])
+    @market1.market_vendors.create!(vendor_id: vendor_ids[3])
+    @market1.market_vendors.create!(vendor_id: vendor_ids[4])
+  end
+  
+  describe 'GET /vendors/:id' do
+    context 'using a valid vendor ID (happy path)' do
+      it 'returns the vendors details' do
+        vendor_id = @market_vendor1.vendor_id
+
+        get "/api/v0/vendors/#{vendor_id}"
+        
+        expect(response).to be_successful
+
+        vendor = JSON.parse(response.body, symbolize_names: true)[:data]
+
+        expect(vendor).to have_key(:id)
+        expect(vendor[:id]).to be_an(String)
+        expect(vendor[:type]).to eq('vendor')
+
+        expect(vendor[:attributes]).to have_key(:name)
+        expect(vendor[:attributes][:name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:description)
+        expect(vendor[:attributes][:description]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_name)
+        expect(vendor[:attributes][:contact_name]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:contact_phone)
+        expect(vendor[:attributes][:contact_phone]).to be_a(String)
+
+        expect(vendor[:attributes]).to have_key(:credit_accepted)
+        expect(vendor[:attributes][:credit_accepted]).to eq(true).or eq(false)
+      end
+    end
+
+    context 'using a invalid vendor ID (sad path)' do
+      it 'returns a 404 error' do
+        vendor_id = 123123123123123
+
+        get "/api/v0/vendors/#{vendor_id}"
+        
+        expect(response).to_not be_successful
+        expect(response.status).to eq(404)
+
+        not_found = JSON.parse(response.body, symbolize_names: true)
+
+        expect(not_found).to have_key(:errors)
+        expect(not_found[:errors]).to be_an(Array)
+
+        expect(not_found[:errors].first).to have_key(:details)
+        expect(not_found[:errors].first[:details]).to be_a(String)
+        expect(not_found[:errors].first[:details]).to eq("Couldn't find Vendor with 'id'=123123123123123")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Description of Changes
- Add tests for happy & sad paths for GET (/vendors/:id)
- Add #show route and action for VendorsController, leveraging an exception handler to rescue a request with an invalid id
- Updates all exception handlers to use `rescue ActiveRecord::RecordNotFound => e` instead of `StandardError`
- Updates the error serializer name from ErrorMarketSerializer to ErrorSerializer to allow reusability

### Testing
- [x] Simplecov at 100% for test suite
- [x]  All Postman tests are passing