### PR TITLE
6 create a vendor

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -14,4 +14,17 @@ class Api::V0::VendorsController < ApplicationController
       render json: ErrorSerializer.new(e).serialized_json, status: :not_found
     end
   end
+
+  def create
+    begin
+      render json: Vendor.create!(vendor_params), status: :created
+    rescue ActiveRecord::RecordInvalid => e
+      render json: ErrorSerializer.new(e).serialized_json, status: :bad_request
+    end
+  end
+
+  private
+  def vendor_params
+    params.require(:vendor).permit(:name, :description, :contact_name, :contact_phone, :credit_accepted)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :markets, only: [:index, :show] do
         resources :vendors, only: [:index]
       end
-      resources :vendors, only: [:show]
+      resources :vendors, only: [:show, :create]
     end
   end
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -67,4 +67,61 @@ RSpec.describe 'Vendors API' do
       end
     end
   end
+
+  describe 'POST /vendors/:id' do
+    context 'using valid inputs for Vendor attributes' do
+      it 'should successfully create a Vendor' do
+        vendor_params = ({
+          name: "Buzzy Bees",
+          description: "Local honey and wax products",
+          contact_name: "Scarlett Johansson",
+          contact_phone: "8389928383",
+          credit_accepted: true
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+
+        post '/api/v0/vendors', headers: headers, params: JSON.generate(vendor: vendor_params)
+
+        created_vendor = Vendor.last
+        
+        expect(response).to be_successful
+        expect(response.status).to eq(201)
+
+        expect(created_vendor.name).to eq("Buzzy Bees")
+        expect(created_vendor.description).to eq("Local honey and wax products")
+        expect(created_vendor.contact_name).to eq("Scarlett Johansson")
+        expect(created_vendor.contact_phone).to eq("8389928383")
+        expect(created_vendor.credit_accepted).to eq(true)
+      end
+    end
+
+    context 'using invalid inputs for Vendor attributes' do
+      it 'should send a 400 error' do
+        vendor_params = ({
+          name: "", # name blank
+          description: "Local honey and wax products",
+          contact_name: "Scarlett Johansson",
+          # contact_phone blank
+          credit_accepted: false
+        })
+
+        headers = {"CONTENT_TYPE" => "application/json"}
+
+        post '/api/v0/vendors', headers: headers, params: JSON.generate(vendor: vendor_params)
+        
+       
+        expect(response.status).to eq(400)
+ 
+        not_found = JSON.parse(response.body, symbolize_names: true)
+
+        expect(not_found).to have_key(:errors)
+        expect(not_found[:errors]).to be_an(Array)
+
+        expect(not_found[:errors].first).to have_key(:details)
+        expect(not_found[:errors].first[:details]).to be_a(String)
+        expect(not_found[:errors].first[:details]).to eq("Validation failed: Name can't be blank, Contact phone can't be blank")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description of Changes
- Add testing for happy & sad paths for creating a new vendor (POST '/api/v0/vendors')
- Add #create route and action for Vendor controller
- Leveraging an exception handler to send created vendors to status 201 :created when successful, and status 400 :bad_request when errors occur

### Testing
- [x] Simplecov coverage at 100%
- [x] Postman tests are passing 