### PR TITLE
8 delete a vendor

### DIFF
--- a/app/controllers/api/v0/vendors_controller.rb
+++ b/app/controllers/api/v0/vendors_controller.rb
@@ -34,6 +34,14 @@ class Api::V0::VendorsController < ApplicationController
     end
   end
 
+  def destroy
+    begin
+      render json: Vendor.destroy(params[:id]), status: :no_content
+    rescue ActiveRecord::RecordNotFound => e
+      render json: ErrorSerializer.new(e).serialized_json, status: :not_found
+    end
+  end
+
   private
   def vendor_params
     params.require(:vendor).permit(:name, :description, :contact_name, :contact_phone, :credit_accepted)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
       resources :markets, only: [:index, :show] do
         resources :vendors, only: [:index]
       end
-      resources :vendors, only: [:show, :create, :update]
+      resources :vendors, only: [:show, :create, :update, :destroy]
     end
   end
 end

--- a/spec/requests/api/v0/vendors_request_spec.rb
+++ b/spec/requests/api/v0/vendors_request_spec.rb
@@ -79,7 +79,6 @@ RSpec.describe 'Vendors API' do
           contact_phone: "8389928383",
           credit_accepted: true
         })
-
         headers = {"CONTENT_TYPE" => "application/json"}
 
         post '/api/v0/vendors', headers: headers, params: JSON.generate(vendor: vendor_params)
@@ -88,7 +87,6 @@ RSpec.describe 'Vendors API' do
         expect(response.status).to eq(201)
 
         created_vendor = JSON.parse(response.body, symbolize_names: true)[:data]
-
 
         expect(created_vendor[:attributes][:name]).to eq("Buzzy Bees")
         expect(created_vendor[:attributes][:description]).to eq("Local honey and wax products")
@@ -101,13 +99,12 @@ RSpec.describe 'Vendors API' do
     context 'using invalid inputs for Vendor attributes' do
       it 'should send a 400 error (bad request)' do
         vendor_params = ({
-          name: "", # name blank
-          description: "Local honey and wax products",
-          contact_name: "Scarlett Johansson",
-          # contact_phone blank
-          credit_accepted: false
-        })
-
+                          name: "", # name blank
+                          description: "Local honey and wax products",
+                          contact_name: "Scarlett Johansson",
+                          # contact_phone blank
+                          credit_accepted: false
+                        })
         headers = {"CONTENT_TYPE" => "application/json"}
 
         post '/api/v0/vendors', headers: headers, params: JSON.generate(vendor: vendor_params)
@@ -132,12 +129,7 @@ RSpec.describe 'Vendors API' do
           expect(@vendor1.description).to_not eq("Local honey and wax products")
           
           id = @vendor1.id
-
-          vendor_params = ({
-            name: "Buzzy Bees",
-            description: "Local honey and wax products",
-          })
-  
+          vendor_params = ( {name: "Buzzy Bees", description: "Local honey and wax products" })
           headers = {"CONTENT_TYPE" => "application/json"}
   
           patch "/api/v0/vendors/#{id}", headers: headers, params: JSON.generate(vendor: vendor_params)
@@ -155,12 +147,7 @@ RSpec.describe 'Vendors API' do
       context 'using invalid vendor ID' do
         it 'should send a 404 error (not found)' do
           id = 123123123123123
-
-          vendor_params = ({
-            name: "Buzzy Bees",
-            description: "Local honey and wax products",
-          })
-  
+          vendor_params = ({ name: "Buzzy Bees", description: "Local honey and wax products" })
           headers = {"CONTENT_TYPE" => "application/json"}
 
           patch "/api/v0/vendors/#{id}", headers: headers, params: JSON.generate(vendor: vendor_params)
@@ -176,11 +163,7 @@ RSpec.describe 'Vendors API' do
       context 'using invalid inputs to update Vendor attributes' do
         it 'should send a 400 error (bad request)' do
           id = @vendor1.id
-
-          vendor_params = ({
-            description: "" #cannot be blank
-          })
-  
+          vendor_params = ({ description: "" }) #cannot be blank
           headers = {"CONTENT_TYPE" => "application/json"}
   
           patch "/api/v0/vendors/#{id}", headers: headers, params: JSON.generate(vendor: vendor_params)
@@ -191,6 +174,34 @@ RSpec.describe 'Vendors API' do
           not_found = JSON.parse(response.body, symbolize_names: true)[:errors].first
 
           expect(not_found[:details]).to eq("Validation failed: Description can't be blank")
+        end
+      end
+    end
+    describe 'DELETE /vendors/:id' do
+      context 'using valid Vendor ID' do
+        it 'sends code 204 (:no_content)' do
+          id = @vendor1.id
+          
+          delete "/api/v0/vendors/#{id}"
+
+          expect(response).to be_successful
+          expect(response.status).to eq(204)
+
+          expect(response.body).to eq("")
+        end
+      end
+
+      context 'using invalid Vendor ID' do
+        it 'sends code 404 (not found)' do
+          id = 123123123123123
+          
+          delete "/api/v0/vendors/#{id}"
+
+          expect(response.status).to eq(404)
+
+          not_found = JSON.parse(response.body, symbolize_names: true)[:errors].first
+
+          expect(not_found[:details]).to eq("Couldn't find Vendor with 'id'=123123123123123")
         end
       end
     end


### PR DESCRIPTION
### Description of Changes
- Add tests for happy/sad paths when deleting a vendor
- Adds #destroy route and controller action for deleting a vendor
  - Leverages an exception handler to send happy to 204 (blank) and sad to 404 (not found)

### Testing
- [x] Simplecov coverage at 100%
- [x] Postman tests are passing 