### PR TITLE
10 delete a marketvendor

### DIFF
--- a/app/controllers/api/v0/market_vendors_controller.rb
+++ b/app/controllers/api/v0/market_vendors_controller.rb
@@ -9,6 +9,15 @@ class Api::V0::MarketVendorsController < ApplicationController
     end
   end
 
+  def destroy
+    begin
+      market_vendor = MarketVendor.find_by!(market_vendor_params)
+      render json: market_vendor.destroy, status: :no_content
+    rescue ActiveRecord::RecordNotFound => e
+      custom_error_code(e)
+    end
+  end
+
   
   private
   def market_vendor_params
@@ -18,7 +27,9 @@ class Api::V0::MarketVendorsController < ApplicationController
   def custom_error_code(error)
     if error.message.include?("must exist")
       render json: ErrorSerializer.new(error).serialized_json, status: :not_found
-    elsif error.message.include?("Market vendor asociation")
+    elsif error.message.include?("Couldn't find MarketVendor")
+      render json: ErrorSerializer.new(error).serialized_non_existent(market_vendor_params), status: :not_found
+    elsif error.message.include?("already exists")
       render json: ErrorSerializer.new(error).serialized_json, status: :unprocessable_entity
     end
   end

--- a/app/models/market_vendor.rb
+++ b/app/models/market_vendor.rb
@@ -3,11 +3,11 @@ class MarketVendor < ApplicationRecord
   belongs_to :vendor
   
   validate :cannot_already_exist, on: :create
-
+  
 private
   def cannot_already_exist
     if MarketVendor.exists?(market_id: market_id, vendor_id: vendor_id)
-      errors.add(:base, "Market vendor asociation between market with market_id=#{market.id} and vendor_id=#{vendor.id} already exists")
+      errors.add(:base, "MarketVendor association between market with market_id=#{market.id} and vendor_id=#{vendor.id} already exists")
     end
   end
 end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -12,4 +12,14 @@ class ErrorSerializer
       ]
     }
   end
+
+  def serialized_non_existent(data)
+    {
+      "errors": [
+          { 
+            "details": "Couldn't find MarketVendor with market_vendors.market_id=#{data[:market_id]} AND market_vendors.vendor_id=#{data[:vendor_id]}",
+          }
+      ]
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       end
       resources :vendors, only: [:show, :create, :update, :destroy]
       resources :market_vendors, only: [:create]
+      resource :market_vendors, only: [:destroy]
     end
   end
 end

--- a/spec/models/market_vendor_spec.rb
+++ b/spec/models/market_vendor_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe MarketVendor, type: :model do
       market_vendor = MarketVendor.new(market_id: market.id, vendor_id: vendor.id)
 
       expect(market_vendor).to_not be_valid
-      expect(market_vendor.errors[:base]).to include("Market vendor asociation between market with market_id=#{market.id} and vendor_id=#{vendor.id} already exists")
+      expect(market_vendor.errors[:base]).to include("MarketVendor association between market with market_id=#{market.id} and vendor_id=#{vendor.id} already exists")
     end
   end
 end


### PR DESCRIPTION
### Description of Changes
- Adds tests for happy & sad paths for #destroy action on MarketVendor
- Adds  MarketVendor #destroy route and controller action
- Leverages an exception handler for happy path (MarketVendor exists) and sad path(MarketVendor does not exists and cannot be deleted)
- Adds custom error code via the ErrorSerializer
- Updates the error message for MarketVendor #cannot_already_exist instance method

### Testing

- [x] Simplecov coverage at 100%
- [x] Postman tests are passing